### PR TITLE
Add --site option to control onsite/offsite/any job routing

### DIFF
--- a/emphgridutils/bin/submit_emph_art.py
+++ b/emphgridutils/bin/submit_emph_art.py
@@ -186,7 +186,7 @@ def build_generator_jobsub_command(
         f"dropbox://{args.generator.resolve()}",
         "-f",
         f"dropbox://{args.template.resolve()}",
-        *basic_jobsub_args(host_out_dir, payload_tarball, test_events=test_events),
+        *basic_jobsub_args(host_out_dir, payload_tarball, test_events=test_events, site=args.site),
         f"file://{wrapper_path}",
     ]
 
@@ -210,7 +210,7 @@ def build_reconstruction_jobsub_command(
         f"dropbox://{args.config.resolve()}",
         "-f",
         f"dropbox://{file_list}",
-        *basic_jobsub_args(host_out_dir, payload_tarball, test_events=test_events),
+        *basic_jobsub_args(host_out_dir, payload_tarball, test_events=test_events, site=args.site),
         f"file://{wrapper_path}",
     ]
 
@@ -335,6 +335,21 @@ def add_common_groups(parser: argparse.ArgumentParser) -> None:
         ),
     )
     environment_args.add_argument("--user", default=os.environ.get("USER"))
+
+    site_args = parser.add_argument_group(
+        "Site selection", "Control where jobs run in the grid."
+    )
+    site_args.add_argument(
+        "--site",
+        choices=["onsite", "offsite", "any"],
+        default="onsite",
+        help=(
+            "Where to route jobs: "
+            "'onsite' (Fermilab only, default), "
+            "'offsite' (remote sites only), "
+            "'any' (scheduler decides)"
+        ),
+    )
 
     debugging_args = parser.add_argument_group(
         "Debugging options", "Print extra diagnostics and avoid submission when requested."

--- a/emphgridutils/bin/submit_emph_art_core.py
+++ b/emphgridutils/bin/submit_emph_art_core.py
@@ -96,8 +96,15 @@ def basic_jobsub_args(
     host_out_dir: Path,
     payload_tarball: Path,
     test_events: int | None = None,
+    site: str = "onsite",
 ) -> list[str]:
-    """Return standard EMPHATIC ``jobsub_submit`` arguments shared by all modes."""
+    """Return standard EMPHATIC ``jobsub_submit`` arguments shared by all modes.
+
+    ``site`` controls where jobs are routed:
+    - ``"onsite"``  -- ``--onsite``  (Fermilab only; default)
+    - ``"offsite"`` -- ``--offsite`` (remote sites only)
+    - ``"any"``     -- no site flag  (scheduler decides)
+    """
     args = [
         "-G",
         "emphatic",
@@ -110,6 +117,11 @@ def basic_jobsub_args(
         f"dropbox://{payload_tarball}",
         "--use-cvmfs-dropbox",
     ]
+    if site == "onsite":
+        args.append("--onsite")
+    elif site == "offsite":
+        args.append("--offsite")
+    # site == "any": no flag — scheduler decides
     if test_events is not None:
         args.extend(["-e", f"EMPH_TEST_EVENTS={test_events}"])
     return args


### PR DESCRIPTION
Adds a --site {onsite,offsite,any} argument (default: onsite) to the shared argument group. basic_jobsub_args() now accepts a site parameter and appends --onsite or --offsite to the jobsub_submit argv accordingly; 'any' emits no flag and lets the scheduler decide.